### PR TITLE
Parse alternative syntaxes, not the current ones

### DIFF
--- a/guide/chapter5.txt
+++ b/guide/chapter5.txt
@@ -32,7 +32,7 @@ Text::CSV::Slurp.
 
 [Text::CSV::Slurp link](https://metacpan.org/release/Text-CSV-Slurp).
 
-An Cweb Parser
+An Cweb Alternative
 --------------
 Outline: TBA.
 
@@ -56,7 +56,7 @@ Acronym: LDAP => Lightweight Directory Access Protocol.
 
 [Perl link](https://metacpan.org/release/perl-ldap).
 
-A Make Parser
+A Make Alternative
 -------------
 Outline: Make's text file instructions to build a program could be replaced by a modernized file format.
 


### PR DESCRIPTION
In this cases, and perhaps several others, I just don't think trying to duplicate the current syntax is the right way.  I'll elaboriate later.
